### PR TITLE
feat: Add auto-regression (AR) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ model = Soothsayer.new(%{
     yearly: %{enabled: true, fourier_terms: 10},
     weekly: %{enabled: false}
   },
+  ar: %{
+    enabled: true,
+    n_lags: 7,
+    layers: [32, 16],       # optional, for deep AR-Net
+    regularization: 0.1     # optional, L1 regularization for sparse weights
+  },
   epochs: 200,
   learning_rate: 0.005
 })
@@ -114,7 +120,6 @@ Soothsayer is inspired by NeuralProphet but implemented in Elixir with some key 
 
 Soothsayer is a work in progress. The following NeuralProphet features are not yet implemented:
 
-- Auto Regression
 - Lagged Regressors
 - Future Regressors
 - Events and Holidays

--- a/lib/soothsayer.ex
+++ b/lib/soothsayer.ex
@@ -36,6 +36,7 @@ defmodule Soothsayer do
         yearly: %{enabled: true, fourier_terms: 6},
         weekly: %{enabled: true, fourier_terms: 3}
       },
+      ar: %{enabled: false, n_lags: 0, layers: [], regularization: nil},
       epochs: 100,
       learning_rate: 0.01
     }
@@ -69,34 +70,75 @@ defmodule Soothsayer do
     validate_training_data!(data)
     processed_data = Preprocessor.prepare_data(data, "y", "ds", model.config.seasonality)
 
-    y = processed_data["y"] |> Series.to_tensor() |> Nx.as_type({:f, 32}) |> Nx.new_axis(-1)
-    {y_normalized, y_mean, y_std} = normalize(y)
+    y_full = processed_data["y"] |> Series.to_tensor() |> Nx.as_type({:f, 32})
+    {y_full_normalized, y_mean, y_std} = normalize(Nx.new_axis(y_full, -1))
+    y_full_normalized = Nx.flatten(y_full_normalized)
+
+    # Handle AR: create lagged inputs and truncate data
+    {y_normalized, ar_input, n_lags} =
+      if model.config.ar.enabled and model.config.ar.n_lags > 0 do
+        n_lags = model.config.ar.n_lags
+        {ar_lagged, ar_targets} = Preprocessor.create_lagged_inputs(y_full_normalized, n_lags)
+        {ar_targets, ar_lagged, n_lags}
+      else
+        {Nx.new_axis(y_full_normalized, -1), nil, 0}
+      end
+
+    # Build base inputs
+    trend_full =
+      processed_data["ds"] |> Series.to_tensor() |> Nx.as_type({:f, 32}) |> Nx.new_axis(-1)
+
+    yearly_full =
+      get_seasonality_input(
+        processed_data,
+        :yearly,
+        model.config.seasonality.yearly.fourier_terms
+      )
+
+    weekly_full =
+      get_seasonality_input(
+        processed_data,
+        :weekly,
+        model.config.seasonality.weekly.fourier_terms
+      )
+
+    # Truncate inputs if AR is enabled (remove first n_lags rows)
+    {trend, yearly, weekly} =
+      if n_lags > 0 do
+        {
+          Nx.slice(trend_full, [n_lags, 0], [Nx.axis_size(trend_full, 0) - n_lags, 1]),
+          Nx.slice(yearly_full, [n_lags, 0], [Nx.axis_size(yearly_full, 0) - n_lags, Nx.axis_size(yearly_full, 1)]),
+          Nx.slice(weekly_full, [n_lags, 0], [Nx.axis_size(weekly_full, 0) - n_lags, Nx.axis_size(weekly_full, 1)])
+        }
+      else
+        {trend_full, yearly_full, weekly_full}
+      end
 
     x = %{
-      "trend" =>
-        processed_data["ds"] |> Series.to_tensor() |> Nx.as_type({:f, 32}) |> Nx.new_axis(-1),
-      "yearly" =>
-        get_seasonality_input(
-          processed_data,
-          :yearly,
-          model.config.seasonality.yearly.fourier_terms
-        ),
-      "weekly" =>
-        get_seasonality_input(
-          processed_data,
-          :weekly,
-          model.config.seasonality.weekly.fourier_terms
-        )
+      "trend" => trend,
+      "yearly" => yearly,
+      "weekly" => weekly
     }
+
+    # Add AR input if enabled
+    x = if ar_input != nil, do: Map.put(x, "ar", ar_input), else: x
 
     {x_normalized, x_norm} = normalize_inputs(x)
 
     fitted_model = Model.fit(model, x_normalized, y_normalized, model.config.epochs)
 
+    # Store training data for prediction lookups
+    training_data = %{
+      dates: Series.to_list(processed_data["ds"]),
+      y_normalized: Nx.to_flat_list(y_full_normalized)
+    }
+
     %{
       fitted_model
       | config:
-          Map.put(model.config, :normalization, %{x: x_norm, y: %{mean: y_mean, std: y_std}})
+          model.config
+          |> Map.put(:normalization, %{x: x_norm, y: %{mean: y_mean, std: y_std}})
+          |> Map.put(:training_data, training_data)
     }
   end
 
@@ -176,6 +218,15 @@ defmodule Soothsayer do
       "weekly" =>
         get_seasonality_input(processed_x, :weekly, model.config.seasonality.weekly.fourier_terms)
     }
+
+    # Add AR input if enabled
+    x_input =
+      if model.config.ar.enabled and model.config.ar.n_lags > 0 do
+        ar_input = get_ar_input(model, Series.to_list(x))
+        Map.put(x_input, "ar", ar_input)
+      else
+        x_input
+      end
 
     x_normalized = normalize_with_params(x_input, model.config.normalization.x)
 
@@ -265,5 +316,35 @@ defmodule Soothsayer do
       _, %{} = left, %{} = right -> deep_merge(left, right)
       _, _left, right -> right
     end)
+  end
+
+  defp get_ar_input(model, dates) do
+    n_lags = model.config.ar.n_lags
+    training_dates = model.config.training_data.dates
+    training_y = model.config.training_data.y_normalized
+
+    # Create a map from date to index for fast lookup
+    date_to_idx =
+      training_dates
+      |> Enum.with_index()
+      |> Map.new()
+
+    # For each prediction date, get the n_lags previous y values
+    ar_inputs =
+      Enum.map(dates, fn date ->
+        idx = Map.get(date_to_idx, date)
+
+        if idx && idx >= n_lags do
+          # Get y values from idx-n_lags to idx-1
+          Enum.slice(training_y, (idx - n_lags)..(idx - 1))
+        else
+          # For dates at the beginning or not in training, use zeros
+          List.duplicate(0.0, n_lags)
+        end
+      end)
+
+    ar_inputs
+    |> Nx.tensor()
+    |> Nx.as_type({:f, 32})
   end
 end

--- a/lib/soothsayer/model.ex
+++ b/lib/soothsayer/model.ex
@@ -82,14 +82,43 @@ defmodule Soothsayer.Model do
         Axon.constant(0)
       end
 
-    combined = Axon.add([trend, yearly_seasonality, weekly_seasonality])
+    {ar_component, _ar_input} =
+      if config[:ar][:enabled] do
+        ar_input = Axon.input("ar", shape: {nil, config.ar.n_lags})
+        ar_layers = Map.get(config.ar, :layers, [])
 
-    Axon.container(%{
+        ar =
+          case ar_layers do
+            [] ->
+              # Linear AR (current behavior)
+              Axon.dense(ar_input, 1, activation: :linear, name: "ar_dense_out")
+
+            layers ->
+              # Deep AR-Net with hidden layers
+              {hidden, _idx} =
+                Enum.reduce(layers, {ar_input, 0}, fn units, {acc, idx} ->
+                  {Axon.dense(acc, units, activation: :relu, name: "ar_dense_#{idx}"), idx + 1}
+                end)
+
+              Axon.dense(hidden, 1, activation: :linear, name: "ar_dense_out")
+          end
+
+        {ar, ar_input}
+      else
+        {Axon.constant(0), nil}
+      end
+
+    combined = Axon.add([trend, yearly_seasonality, weekly_seasonality, ar_component])
+
+    container = %{
       combined: combined,
       trend: trend,
       yearly_seasonality: yearly_seasonality,
-      weekly_seasonality: weekly_seasonality
-    })
+      weekly_seasonality: weekly_seasonality,
+      ar: ar_component
+    }
+
+    Axon.container(container)
   end
 
   @doc """
@@ -120,19 +149,95 @@ defmodule Soothsayer.Model do
     {init_fn, _predict_fn} = Axon.build(model.network)
     initial_params = init_fn.(x, Axon.ModelState.empty())
 
+    ar_reg = get_in(model.config, [:ar, :regularization])
+
     trained_params =
-      model.network
-      |> Axon.Loop.trainer(
-        &Axon.Losses.huber(&1, &2.combined, reduction: :mean),
-        Polaris.Optimizers.adam(learning_rate: model.config.learning_rate)
-      )
-      |> Axon.Loop.run(Stream.repeatedly(fn -> {x, y} end), initial_params,
-        epochs: epochs,
-        iterations: elem(Nx.shape(y), 0),
-        compiler: EXLA
-      )
+      if ar_reg do
+        # Custom training with L1 regularization on AR weights
+        train_with_regularization(model, x, y, epochs, initial_params, ar_reg)
+      else
+        # Standard training without regularization
+        model.network
+        |> Axon.Loop.trainer(
+          &Axon.Losses.huber(&1, &2.combined, reduction: :mean),
+          Polaris.Optimizers.adam(learning_rate: model.config.learning_rate)
+        )
+        |> Axon.Loop.run(Stream.repeatedly(fn -> {x, y} end), initial_params,
+          epochs: epochs,
+          iterations: elem(Nx.shape(y), 0),
+          compiler: EXLA
+        )
+      end
 
     %{model | params: trained_params}
+  end
+
+  @doc false
+  def train_with_regularization_public(model, x, y, epochs, initial_params, ar_reg) do
+    train_with_regularization(model, x, y, epochs, initial_params, ar_reg)
+  end
+
+  defp train_with_regularization(model, x, y, epochs, initial_params, ar_reg) do
+    # Find AR layer names at runtime
+    ar_layer_names =
+      initial_params.data
+      |> Map.keys()
+      |> Enum.filter(&String.starts_with?(&1, "ar_dense"))
+
+    {_init_fn, predict_fn} = Axon.build(model.network)
+    {init_optim_fn, update_fn} = Polaris.Optimizers.adam(learning_rate: model.config.learning_rate)
+
+    # Define the objective function with L1 penalty
+    objective_fn = fn params, x_input, y_target ->
+      predictions = predict_fn.(params, x_input)
+      base_loss = Axon.Losses.huber(y_target, predictions.combined, reduction: :mean)
+      ar_penalty = compute_ar_l1_penalty_jit(params, ar_layer_names)
+      Nx.add(base_loss, Nx.multiply(ar_reg, ar_penalty))
+    end
+
+    # JIT compile the train step
+    train_step_fn = fn params, opt_state, x_input, y_target ->
+      {loss, grads} = Nx.Defn.value_and_grad(params, fn p -> objective_fn.(p, x_input, y_target) end)
+      {updates, new_opt_state} = update_fn.(grads, opt_state, params)
+      new_params = Polaris.Updates.apply_updates(params, updates)
+      {loss, new_params, new_opt_state}
+    end
+
+    jit_train_step = EXLA.jit(train_step_fn)
+
+    initial_opt_state = init_optim_fn.(initial_params)
+    iterations = elem(Nx.shape(y), 0)
+
+    log_interval = max(div(epochs, 10), 1)
+
+    {final_params, _final_opt_state} =
+      Enum.reduce(1..epochs, {initial_params, initial_opt_state}, fn epoch, {params, opt_state} ->
+        {final_loss, new_params, new_opt_state} =
+          Enum.reduce(1..iterations, {nil, params, opt_state}, fn _iter, {_loss, p, os} ->
+            jit_train_step.(p, os, x, y)
+          end)
+
+        if rem(epoch - 1, log_interval) == 0 do
+          IO.puts("Epoch: #{epoch - 1}, loss: #{Nx.to_number(final_loss)}")
+        end
+
+        {new_params, new_opt_state}
+      end)
+
+    final_params
+  end
+
+  defp compute_ar_l1_penalty_jit(params, ar_layer_names) do
+    if Enum.empty?(ar_layer_names) do
+      Nx.tensor(0.0)
+    else
+      ar_layer_names
+      |> Enum.map(fn layer_name ->
+        kernel = params.data[layer_name]["kernel"]
+        Nx.sum(Nx.abs(kernel))
+      end)
+      |> Enum.reduce(&Nx.add/2)
+    end
   end
 
   @doc """

--- a/lib/soothsayer/preprocessor.ex
+++ b/lib/soothsayer/preprocessor.ex
@@ -98,4 +98,46 @@ defmodule Soothsayer.Preprocessor do
 
     result_df
   end
+
+  @doc """
+  Creates lagged input windows from a time series for auto-regression.
+
+  ## Parameters
+
+    * `y` - An `Nx.Tensor` containing the target values (1D).
+    * `n_lags` - The number of lagged values to include in each window.
+
+  ## Returns
+
+    A tuple `{lagged_inputs, targets}` where:
+    - `lagged_inputs` is a tensor of shape `{n_samples, n_lags}` containing sliding windows
+    - `targets` is a tensor of shape `{n_samples, 1}` containing the target values
+
+  ## Examples
+
+      iex> y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      iex> {lagged, targets} = Soothsayer.Preprocessor.create_lagged_inputs(y, 3)
+      iex> Nx.shape(lagged)
+      {2, 3}
+
+  """
+  @spec create_lagged_inputs(Nx.Tensor.t(), non_neg_integer()) ::
+          {Nx.Tensor.t(), Nx.Tensor.t()}
+  def create_lagged_inputs(y, n_lags) do
+    y = Nx.flatten(y)
+    total = Nx.axis_size(y, 0)
+    n_samples = total - n_lags
+
+    lagged =
+      Enum.map(0..(n_samples - 1), fn i ->
+        Nx.slice(y, [i], [n_lags])
+      end)
+      |> Nx.stack()
+
+    targets =
+      Nx.slice(y, [n_lags], [n_samples])
+      |> Nx.reshape({n_samples, 1})
+
+    {lagged, targets}
+  end
 end

--- a/test/soothsayer/ar_test.exs
+++ b/test/soothsayer/ar_test.exs
@@ -1,0 +1,268 @@
+defmodule Soothsayer.ARTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.DataFrame
+  alias Explorer.Series
+  alias Soothsayer.Preprocessor
+
+  describe "auto-regression config" do
+    test "new/1 includes AR config with defaults" do
+      model = Soothsayer.new()
+
+      assert model.config.ar.enabled == false
+      assert model.config.ar.n_lags == 0
+      assert model.config.ar.layers == []
+      assert model.config.ar.regularization == nil
+    end
+  end
+
+  describe "lagged input preparation" do
+    test "create_lagged_inputs/2 creates sliding windows from y values" do
+      y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      n_lags = 3
+
+      {lagged, targets} = Preprocessor.create_lagged_inputs(y, n_lags)
+
+      # With n_lags=3 and 5 values, we get 2 windows:
+      # Window 1: [1, 2, 3] -> target: 4
+      # Window 2: [2, 3, 4] -> target: 5
+      expected_lagged = Nx.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
+      expected_targets = Nx.tensor([[4.0], [5.0]])
+
+      assert Nx.shape(lagged) == {2, 3}
+      assert Nx.shape(targets) == {2, 1}
+      assert Nx.to_flat_list(lagged) == Nx.to_flat_list(expected_lagged)
+      assert Nx.to_flat_list(targets) == Nx.to_flat_list(expected_targets)
+    end
+  end
+
+  describe "AR network" do
+    test "build_network/1 includes AR input when enabled" do
+      config = %{
+        trend: %{enabled: true},
+        seasonality: %{
+          yearly: %{enabled: true, fourier_terms: 4},
+          weekly: %{enabled: true, fourier_terms: 2}
+        },
+        ar: %{enabled: true, n_lags: 5}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+      inputs = Axon.get_inputs(network)
+
+      assert Map.has_key?(inputs, "ar")
+    end
+
+    test "build_network/1 does not include AR input when disabled" do
+      config = %{
+        trend: %{enabled: true},
+        seasonality: %{
+          yearly: %{enabled: true, fourier_terms: 4},
+          weekly: %{enabled: true, fourier_terms: 2}
+        },
+        ar: %{enabled: false, n_lags: 0}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+      inputs = Axon.get_inputs(network)
+
+      refute Map.has_key?(inputs, "ar")
+    end
+
+    test "build_network/1 builds deep AR-Net with hidden layers" do
+      config = %{
+        trend: %{enabled: false},
+        seasonality: %{
+          yearly: %{enabled: false, fourier_terms: 4},
+          weekly: %{enabled: false, fourier_terms: 2}
+        },
+        ar: %{enabled: true, n_lags: 5, layers: [32, 16]}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+
+      # Build and initialize the network to verify it works
+      {init_fn, predict_fn} = Axon.build(network)
+
+      input = %{
+        "trend" => Nx.tensor([[1.0]]),
+        "yearly" => Nx.broadcast(0.0, {1, 8}),
+        "weekly" => Nx.broadcast(0.0, {1, 4}),
+        "ar" => Nx.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+      }
+
+      params = init_fn.(input, Axon.ModelState.empty())
+
+      # Verify the deep AR-Net has the expected layer structure
+      # With layers: [32, 16], we should have:
+      # - ar_dense_0: {5, 32} weights + {32} bias (5 inputs -> 32 hidden)
+      # - ar_dense_1: {32, 16} weights + {16} bias (32 -> 16 hidden)
+      # - ar_dense_out: {16, 1} weights + {1} bias (16 -> 1 output)
+      assert Map.has_key?(params.data, "ar_dense_0")
+      assert Map.has_key?(params.data, "ar_dense_1")
+      assert Map.has_key?(params.data, "ar_dense_out")
+
+      # Verify prediction works and output has correct shape
+      result = predict_fn.(params, input)
+      assert Nx.shape(result.combined) == {1, 1}
+    end
+
+    test "build_network/1 applies L1 regularization when regularization is set" do
+      # L1 regularization should push weights towards zero during training
+      # We verify by training the same model with and without regularization
+      # using identical initial weights
+      config = %{
+        trend: %{enabled: false},
+        seasonality: %{
+          yearly: %{enabled: false, fourier_terms: 4},
+          weekly: %{enabled: false, fourier_terms: 2}
+        },
+        ar: %{enabled: true, n_lags: 3, layers: [], regularization: nil}
+      }
+
+      # Create training data
+      input = %{
+        "trend" => Nx.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]]),
+        "yearly" => Nx.broadcast(0.0, {5, 8}),
+        "weekly" => Nx.broadcast(0.0, {5, 4}),
+        "ar" => Nx.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0], [4.0, 5.0, 6.0], [5.0, 6.0, 7.0]])
+      }
+      target = Nx.tensor([[4.0], [5.0], [6.0], [7.0], [8.0]])
+
+      # Build network and get initial params
+      network = Soothsayer.Model.build_network(config)
+      {init_fn, _} = Axon.build(network)
+      initial_params = init_fn.(input, Axon.ModelState.empty())
+
+      # Train model WITHOUT regularization using standard loop
+      trained_no_reg =
+        network
+        |> Axon.Loop.trainer(
+          &Axon.Losses.huber(&1, &2.combined, reduction: :mean),
+          Polaris.Optimizers.adam(learning_rate: 0.1)
+        )
+        |> Axon.Loop.run(Stream.repeatedly(fn -> {input, target} end), initial_params,
+          epochs: 100,
+          iterations: 5,
+          compiler: EXLA
+        )
+
+      # Train model WITH regularization using same initial params
+      # We use the Model.fit with regularization which uses custom training loop
+      model_with_reg = %Soothsayer.Model{
+        network: network,
+        config: %{learning_rate: 0.1, ar: %{regularization: 1.0}}
+      }
+
+      trained_reg = Soothsayer.Model.train_with_regularization_public(
+        model_with_reg, input, target, 100, initial_params, 1.0
+      )
+
+      # Get the AR dense layer weights
+      ar_weights_reg = trained_reg.data["ar_dense_out"]["kernel"]
+      ar_weights_no_reg = trained_no_reg.data["ar_dense_out"]["kernel"]
+
+      # L1 regularization should result in smaller weight magnitudes
+      l1_norm_reg = ar_weights_reg |> Nx.abs() |> Nx.sum() |> Nx.to_number()
+      l1_norm_no_reg = ar_weights_no_reg |> Nx.abs() |> Nx.sum() |> Nx.to_number()
+
+      # With L1 regularization, weights should be pushed toward zero
+      assert l1_norm_reg < l1_norm_no_reg,
+        "L1 regularization should reduce weight magnitudes. Got reg: #{l1_norm_reg}, no_reg: #{l1_norm_no_reg}"
+    end
+  end
+
+  describe "AR training and prediction" do
+    test "fit and predict with deep AR-Net learns non-linear pattern" do
+      # Generate data with a non-linear autoregressive pattern
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 200
+      start_date = ~D[2023-01-01]
+
+      # Non-linear pattern: y(t) = sin(y(t-1)/20) * 10 + noise
+      {y_values, _} =
+        Enum.reduce(1..n_points, {[50.0], 50.0}, fn _, {acc, prev} ->
+          next = :math.sin(prev / 20) * 10 + 50 + :rand.normal(0, 2)
+          {[next | acc], next}
+        end)
+
+      y_values = Enum.reverse(y_values) |> Enum.take(n_points)
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      # Create model with deep AR-Net
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false},
+          seasonality: %{
+            yearly: %{enabled: false},
+            weekly: %{enabled: false}
+          },
+          ar: %{enabled: true, n_lags: 5, layers: [16, 8]},
+          epochs: 5
+        })
+
+      # Fit the model
+      fitted_model = Soothsayer.fit(model, df)
+
+      # Make predictions
+      test_dates = Enum.take(dates, -10) |> Series.from_list()
+      predictions = Soothsayer.predict(fitted_model, test_dates)
+
+      # Predictions should have correct shape
+      assert Nx.shape(predictions) == {10, 1}
+
+      # Model should produce non-trivial predictions
+      pred_values = Nx.to_flat_list(predictions)
+      assert Enum.any?(pred_values, fn v -> abs(v - 50) > 1.0 end)
+    end
+
+    test "fit and predict with AR enabled learns autoregressive pattern" do
+      # Generate data with a simple autoregressive pattern: y(t) = 0.8 * y(t-1) + noise
+      # This is an AR(1) process
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 200
+      start_date = ~D[2023-01-01]
+
+      {y_values, _} =
+        Enum.reduce(1..n_points, {[100.0], 100.0}, fn _, {acc, prev} ->
+          next = 0.8 * prev + :rand.normal(0, 5)
+          {[next | acc], next}
+        end)
+
+      y_values = Enum.reverse(y_values) |> Enum.take(n_points)
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      # Create model with AR enabled
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false},
+          seasonality: %{
+            yearly: %{enabled: false},
+            weekly: %{enabled: false}
+          },
+          ar: %{enabled: true, n_lags: 3},
+          epochs: 5
+        })
+
+      # Fit the model
+      fitted_model = Soothsayer.fit(model, df)
+
+      # Make predictions for the last few dates (in-sample)
+      test_dates = Enum.take(dates, -10) |> Series.from_list()
+      predictions = Soothsayer.predict(fitted_model, test_dates)
+
+      # Predictions should be tensors with the right shape
+      assert Nx.shape(predictions) == {10, 1}
+
+      # The model should have learned something (predictions shouldn't be all zeros)
+      pred_values = Nx.to_flat_list(predictions)
+      assert Enum.any?(pred_values, fn v -> abs(v) > 1.0 end)
+    end
+  end
+end


### PR DESCRIPTION
Adds auto-regression to Soothsayer, bringing us closer to NeuralProphet's feature set.

You can now model time series that depend on their own past values:

```elixir
model = Soothsayer.new(%{
  ar: %{enabled: true, n_lags: 7}
})
```

Also supports deep AR-Net for non-linear patterns and L1 regularization for sparse weights:

```elixir
ar: %{enabled: true, n_lags: 7, layers: [32, 16], regularization: 0.1}
```

Changes:
- AR component with configurable lags
- Deep AR-Net with hidden layers
- L1 regularization via custom training loop
- Lagged input creation in preprocessor
- Updated README