### PR TITLE
feat: Add get_ar_weights/1 for AR layer weight inspection

### DIFF
--- a/lib/soothsayer.ex
+++ b/lib/soothsayer.ex
@@ -347,4 +347,46 @@ defmodule Soothsayer do
     |> Nx.tensor()
     |> Nx.as_type({:f, 32})
   end
+
+  @doc """
+  Extracts the raw AR layer weights from a fitted model.
+
+  For linear AR models, returns the output layer weights.
+  For deep AR-Net models, returns all layer weights including hidden layers.
+
+  ## Parameters
+
+    * `model` - A fitted `Soothsayer.Model` struct with AR enabled.
+
+  ## Returns
+
+    A map of layer names to weight structs containing `:kernel` and `:bias` tensors.
+
+  ## Examples
+
+      iex> model = Soothsayer.new(%{ar: %{enabled: true, n_lags: 3}})
+      iex> fitted_model = Soothsayer.fit(model, data)
+      iex> weights = Soothsayer.get_ar_weights(fitted_model)
+      %{
+        "ar_dense_out" => %{kernel: #Nx.Tensor<f32[3][1]>, bias: #Nx.Tensor<f32[1]>}
+      }
+
+  """
+  @spec get_ar_weights(Soothsayer.Model.t()) :: %{String.t() => %{kernel: Nx.Tensor.t(), bias: Nx.Tensor.t()}}
+  def get_ar_weights(%Model{} = model) do
+    unless model.config.ar.enabled do
+      raise ArgumentError, "AR is not enabled on this model"
+    end
+
+    unless model.params do
+      raise ArgumentError, "Model has not been fitted yet"
+    end
+
+    model.params.data
+    |> Enum.filter(fn {name, _} -> String.starts_with?(name, "ar_dense") end)
+    |> Enum.map(fn {name, layer} ->
+      {name, %{kernel: layer["kernel"], bias: layer["bias"]}}
+    end)
+    |> Enum.into(%{})
+  end
 end

--- a/test/soothsayer/ar_test.exs
+++ b/test/soothsayer/ar_test.exs
@@ -265,4 +265,84 @@ defmodule Soothsayer.ARTest do
       assert Enum.any?(pred_values, fn v -> abs(v) > 1.0 end)
     end
   end
+
+  describe "get_ar_weights/1" do
+    test "returns weights for linear AR model" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false},
+          seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+          ar: %{enabled: true, n_lags: 3},
+          epochs: 2
+        })
+
+      fitted_model = Soothsayer.fit(model, df)
+      weights = Soothsayer.get_ar_weights(fitted_model)
+
+      # Should have only the output layer for linear AR
+      assert Map.has_key?(weights, "ar_dense_out")
+      assert map_size(weights) == 1
+
+      # Kernel should be {n_lags, 1}
+      assert Nx.shape(weights["ar_dense_out"].kernel) == {3, 1}
+      assert Nx.shape(weights["ar_dense_out"].bias) == {1}
+    end
+
+    test "returns all layer weights for deep AR-Net" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false},
+          seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+          ar: %{enabled: true, n_lags: 5, layers: [16, 8]},
+          epochs: 2
+        })
+
+      fitted_model = Soothsayer.fit(model, df)
+      weights = Soothsayer.get_ar_weights(fitted_model)
+
+      # Should have hidden layers + output layer
+      assert Map.has_key?(weights, "ar_dense_0")
+      assert Map.has_key?(weights, "ar_dense_1")
+      assert Map.has_key?(weights, "ar_dense_out")
+
+      # Verify shapes
+      assert Nx.shape(weights["ar_dense_0"].kernel) == {5, 16}
+      assert Nx.shape(weights["ar_dense_1"].kernel) == {16, 8}
+      assert Nx.shape(weights["ar_dense_out"].kernel) == {8, 1}
+    end
+
+    test "raises error when AR is disabled" do
+      model = Soothsayer.new(%{ar: %{enabled: false}})
+
+      assert_raise ArgumentError, ~r/AR is not enabled/, fn ->
+        Soothsayer.get_ar_weights(model)
+      end
+    end
+
+    test "raises error when model is not fitted" do
+      model = Soothsayer.new(%{ar: %{enabled: true, n_lags: 3}})
+
+      assert_raise ArgumentError, ~r/not been fitted/, fn ->
+        Soothsayer.get_ar_weights(model)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds `get_ar_weights/1` to extract raw AR layer weights from fitted models.

Works with both linear AR (single layer) and deep AR-Net (multiple hidden layers).

```elixir
# Linear AR
weights = Soothsayer.get_ar_weights(fitted_model)
# => %{"ar_dense_out" => %{kernel: #Nx.Tensor<...>, bias: #Nx.Tensor<...>}}

# Deep AR-Net with layers: [16, 8]
weights = Soothsayer.get_ar_weights(fitted_model)
# => %{
#   "ar_dense_0" => %{kernel: ..., bias: ...},
#   "ar_dense_1" => %{kernel: ..., bias: ...},
#   "ar_dense_out" => %{kernel: ..., bias: ...}
# }
```

Raises `ArgumentError` if AR is disabled or model is not fitted.