### PR TITLE
feat: Add piecewise linear trend with changepoint detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ Soothsayer.new(%{
 
 Good for: sales growth, user adoption, gradual temperature changes.
 
+#### Changepoints
+
+By default, Soothsayer uses piecewise linear trends with automatic changepoint detection. This allows the trend to change slope at multiple points, capturing shifts in growth rate (e.g., a product launch, market change, or policy update).
+
+```elixir
+Soothsayer.new(%{
+  trend: %{
+    n_changepoints: 10,      # number of potential changepoints (default: 10)
+    changepoints_range: 0.8  # place changepoints in first 80% of data (default: 0.8)
+  }
+})
+```
+
+The model learns which changepoints matter and how much the slope changes at each one. Setting `n_changepoints: 0` disables changepoints and uses a simple linear trend.
+
+**Trend regularization** can prevent overfitting when you have many changepoints:
+
+```elixir
+trend: %{
+  n_changepoints: 25,
+  regularization: 0.1  # L1 penalty pushes small slope changes toward zero
+}
+```
+
+This is useful when you're not sure how many changepoints you need. Set more than you think necessary and let regularization prune the unimportant ones.
+
 ### Seasonality
 
 Captures repeating patterns at fixed intervals. Soothsayer supports yearly and weekly seasonality using Fourier terms.
@@ -193,7 +219,6 @@ The following NeuralProphet features are on the roadmap:
 - Events and Holidays
 - Uncertainty Estimation
 - Multiplicative Seasonality
-- Changepoint Detection
 
 ## Contributing
 

--- a/lib/soothsayer.ex
+++ b/lib/soothsayer.ex
@@ -5,6 +5,8 @@ defmodule Soothsayer do
 
   alias Explorer.DataFrame
   alias Explorer.Series
+  alias Soothsayer.AR
+  alias Soothsayer.Changepoints
   alias Soothsayer.Model
   alias Soothsayer.Preprocessor
 
@@ -31,7 +33,12 @@ defmodule Soothsayer do
   @spec new(map()) :: Soothsayer.Model.t()
   def new(config \\ %{}) do
     default_config = %{
-      trend: %{enabled: true},
+      trend: %{
+        enabled: true,
+        n_changepoints: 10,
+        changepoints_range: 0.8,
+        regularization: nil
+      },
       seasonality: %{
         yearly: %{enabled: true, fourier_terms: 6},
         weekly: %{enabled: true, fourier_terms: 3}
@@ -78,15 +85,29 @@ defmodule Soothsayer do
     {y_normalized, ar_input, n_lags} =
       if model.config.ar.enabled and model.config.ar.n_lags > 0 do
         n_lags = model.config.ar.n_lags
-        {ar_lagged, ar_targets} = Preprocessor.create_lagged_inputs(y_full_normalized, n_lags)
+        {ar_lagged, ar_targets} = AR.create_lagged_inputs(y_full_normalized, n_lags)
         {ar_targets, ar_lagged, n_lags}
       else
         {Nx.new_axis(y_full_normalized, -1), nil, 0}
       end
 
-    # Build base inputs
-    trend_full =
-      processed_data["ds"] |> Series.to_tensor() |> Nx.as_type({:f, 32}) |> Nx.new_axis(-1)
+    # Extract dates and compute changepoint info
+    dates = Series.to_list(processed_data["ds"])
+    first_date = List.first(dates)
+    n_changepoints = model.config.trend.n_changepoints
+    changepoints_range = model.config.trend.changepoints_range
+
+    # Compute changepoint positions as numeric values (days since first date)
+    changepoint_positions = compute_numeric_changepoint_positions(dates, first_date, n_changepoints, changepoints_range)
+
+    # Build base time values tensor (days since first date)
+    t_full = Changepoints.date_to_numeric(dates, first_date) |> Nx.new_axis(-1)
+
+    # Build changepoint features
+    changepoint_features_full = Changepoints.build_changepoint_features(t_full, changepoint_positions)
+
+    # Build trend input with changepoint features
+    trend_full = Changepoints.build_trend_input(t_full, changepoint_features_full)
 
     yearly_full =
       get_seasonality_input(
@@ -105,8 +126,9 @@ defmodule Soothsayer do
     # Truncate inputs if AR is enabled (remove first n_lags rows)
     {trend, yearly, weekly} =
       if n_lags > 0 do
+        trend_cols = Nx.axis_size(trend_full, 1)
         {
-          Nx.slice(trend_full, [n_lags, 0], [Nx.axis_size(trend_full, 0) - n_lags, 1]),
+          Nx.slice(trend_full, [n_lags, 0], [Nx.axis_size(trend_full, 0) - n_lags, trend_cols]),
           Nx.slice(yearly_full, [n_lags, 0], [Nx.axis_size(yearly_full, 0) - n_lags, Nx.axis_size(yearly_full, 1)]),
           Nx.slice(weekly_full, [n_lags, 0], [Nx.axis_size(weekly_full, 0) - n_lags, Nx.axis_size(weekly_full, 1)])
         }
@@ -129,7 +151,7 @@ defmodule Soothsayer do
 
     # Store training data for prediction lookups
     training_data = %{
-      dates: Series.to_list(processed_data["ds"]),
+      dates: dates,
       y_normalized: Nx.to_flat_list(y_full_normalized)
     }
 
@@ -139,7 +161,14 @@ defmodule Soothsayer do
           model.config
           |> Map.put(:normalization, %{x: x_norm, y: %{mean: y_mean, std: y_std}})
           |> Map.put(:training_data, training_data)
+          |> Map.put(:first_date, first_date)
+          |> Map.put(:changepoint_positions, changepoint_positions)
     }
+  end
+
+  defp compute_numeric_changepoint_positions(dates, first_date, n_changepoints, changepoints_range) do
+    changepoint_dates = Changepoints.compute_changepoint_positions(dates, n_changepoints, changepoints_range)
+    Enum.map(changepoint_dates, fn date -> Date.diff(date, first_date) * 1.0 end)
   end
 
   @doc """
@@ -210,9 +239,17 @@ defmodule Soothsayer do
     processed_x =
       Preprocessor.prepare_data(DataFrame.new(%{"ds" => x}), nil, "ds", model.config.seasonality)
 
+    # Build trend input with changepoint features using stored positions
+    prediction_dates = Series.to_list(x)
+    first_date = model.config.first_date
+    changepoint_positions = model.config.changepoint_positions
+
+    t = Changepoints.date_to_numeric(prediction_dates, first_date) |> Nx.new_axis(-1)
+    changepoint_features = Changepoints.build_changepoint_features(t, changepoint_positions)
+    trend_input = Changepoints.build_trend_input(t, changepoint_features)
+
     x_input = %{
-      "trend" =>
-        processed_x["ds"] |> Series.to_tensor() |> Nx.as_type({:f, 32}) |> Nx.new_axis(-1),
+      "trend" => trend_input,
       "yearly" =>
         get_seasonality_input(processed_x, :yearly, model.config.seasonality.yearly.fourier_terms),
       "weekly" =>
@@ -222,7 +259,7 @@ defmodule Soothsayer do
     # Add AR input if enabled
     x_input =
       if model.config.ar.enabled and model.config.ar.n_lags > 0 do
-        ar_input = get_ar_input(model, Series.to_list(x))
+        ar_input = AR.build_input(model.config.training_data, Series.to_list(x), model.config.ar.n_lags)
         Map.put(x_input, "ar", ar_input)
       else
         x_input
@@ -318,36 +355,6 @@ defmodule Soothsayer do
     end)
   end
 
-  defp get_ar_input(model, dates) do
-    n_lags = model.config.ar.n_lags
-    training_dates = model.config.training_data.dates
-    training_y = model.config.training_data.y_normalized
-
-    # Create a map from date to index for fast lookup
-    date_to_idx =
-      training_dates
-      |> Enum.with_index()
-      |> Map.new()
-
-    # For each prediction date, get the n_lags previous y values
-    ar_inputs =
-      Enum.map(dates, fn date ->
-        idx = Map.get(date_to_idx, date)
-
-        if idx && idx >= n_lags do
-          # Get y values from idx-n_lags to idx-1
-          Enum.slice(training_y, (idx - n_lags)..(idx - 1))
-        else
-          # For dates at the beginning or not in training, use zeros
-          List.duplicate(0.0, n_lags)
-        end
-      end)
-
-    ar_inputs
-    |> Nx.tensor()
-    |> Nx.as_type({:f, 32})
-  end
-
   @doc """
   Extracts the raw AR layer weights from a fitted model.
 
@@ -374,19 +381,6 @@ defmodule Soothsayer do
   """
   @spec get_ar_weights(Soothsayer.Model.t()) :: %{String.t() => %{kernel: Nx.Tensor.t(), bias: Nx.Tensor.t()}}
   def get_ar_weights(%Model{} = model) do
-    unless model.config.ar.enabled do
-      raise ArgumentError, "AR is not enabled on this model"
-    end
-
-    unless model.params do
-      raise ArgumentError, "Model has not been fitted yet"
-    end
-
-    model.params.data
-    |> Enum.filter(fn {name, _} -> String.starts_with?(name, "ar_dense") end)
-    |> Enum.map(fn {name, layer} ->
-      {name, %{kernel: layer["kernel"], bias: layer["bias"]}}
-    end)
-    |> Enum.into(%{})
+    AR.get_weights(model)
   end
 end

--- a/lib/soothsayer/ar.ex
+++ b/lib/soothsayer/ar.ex
@@ -1,0 +1,136 @@
+defmodule Soothsayer.AR do
+  @moduledoc """
+  Auto-regression (AR) component functionality.
+
+  Handles creation of lagged inputs and extraction of AR weights from fitted models.
+  """
+
+  @doc """
+  Creates lagged input features and corresponding targets for AR training.
+
+  Given a time series y and number of lags, creates sliding windows where each
+  window contains n_lags consecutive values, and the target is the next value.
+
+  ## Parameters
+
+    * `y` - A 1D tensor of time series values.
+    * `n_lags` - Number of lagged values to use as features.
+
+  ## Returns
+
+    A tuple `{lagged, targets}` where:
+    * `lagged` - Tensor of shape `{n_samples, n_lags}` with lagged features
+    * `targets` - Tensor of shape `{n_samples, 1}` with target values
+
+  ## Examples
+
+      iex> y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      iex> {lagged, targets} = Soothsayer.AR.create_lagged_inputs(y, 3)
+      iex> Nx.shape(lagged)
+      {2, 3}
+
+  """
+  @spec create_lagged_inputs(Nx.Tensor.t(), non_neg_integer()) ::
+          {Nx.Tensor.t(), Nx.Tensor.t()}
+  def create_lagged_inputs(y, n_lags) do
+    y_list = Nx.to_flat_list(y)
+    n = length(y_list)
+
+    {lagged_list, target_list} =
+      Enum.reduce((n_lags)..(n - 1), {[], []}, fn i, {lagged_acc, target_acc} ->
+        window = Enum.slice(y_list, (i - n_lags)..(i - 1))
+        target = Enum.at(y_list, i)
+        {[window | lagged_acc], [target | target_acc]}
+      end)
+
+    lagged = lagged_list |> Enum.reverse() |> Nx.tensor() |> Nx.as_type({:f, 32})
+    targets = target_list |> Enum.reverse() |> Nx.tensor() |> Nx.reshape({:auto, 1}) |> Nx.as_type({:f, 32})
+
+    {lagged, targets}
+  end
+
+  @doc """
+  Builds AR input tensor for prediction given training data and prediction dates.
+
+  For each prediction date, looks up the previous n_lags values from the training
+  data to use as AR features. Returns zeros for dates that don't have enough history.
+
+  ## Parameters
+
+    * `training_data` - Map with `:dates` (list of dates) and `:y_normalized` (list of values)
+    * `prediction_dates` - List of dates to build AR inputs for
+    * `n_lags` - Number of lagged values to include
+
+  ## Returns
+
+    A tensor of shape `{n_predictions, n_lags}` with AR features.
+
+  """
+  @spec build_input(map(), list(), non_neg_integer()) :: Nx.Tensor.t()
+  def build_input(training_data, prediction_dates, n_lags) do
+    training_dates = training_data.dates
+    training_y = training_data.y_normalized
+
+    # Create a map from date to index for fast lookup
+    date_to_idx =
+      training_dates
+      |> Enum.with_index()
+      |> Map.new()
+
+    # For each prediction date, get the n_lags previous y values
+    ar_inputs =
+      Enum.map(prediction_dates, fn date ->
+        idx = Map.get(date_to_idx, date)
+
+        if idx && idx >= n_lags do
+          # Get y values from idx-n_lags to idx-1
+          Enum.slice(training_y, (idx - n_lags)..(idx - 1))
+        else
+          # For dates at the beginning or not in training, use zeros
+          List.duplicate(0.0, n_lags)
+        end
+      end)
+
+    ar_inputs
+    |> Nx.tensor()
+    |> Nx.as_type({:f, 32})
+  end
+
+  @doc """
+  Extracts raw AR layer weights from a fitted model.
+
+  For linear AR models, returns the output layer weights.
+  For deep AR-Net models, returns all layer weights including hidden layers.
+
+  ## Parameters
+
+    * `model` - A fitted `Soothsayer.Model` struct with AR enabled.
+
+  ## Returns
+
+    A map of layer names to weight structs containing `:kernel` and `:bias` tensors.
+
+  ## Examples
+
+      iex> weights = Soothsayer.AR.get_weights(fitted_model)
+      %{"ar_dense_out" => %{kernel: #Nx.Tensor<...>, bias: #Nx.Tensor<...>}}
+
+  """
+  @spec get_weights(Soothsayer.Model.t()) :: %{String.t() => %{kernel: Nx.Tensor.t(), bias: Nx.Tensor.t()}}
+  def get_weights(%Soothsayer.Model{} = model) do
+    unless model.config.ar.enabled do
+      raise ArgumentError, "AR is not enabled on this model"
+    end
+
+    unless model.params do
+      raise ArgumentError, "Model has not been fitted yet"
+    end
+
+    model.params.data
+    |> Enum.filter(fn {name, _} -> String.starts_with?(name, "ar_dense") end)
+    |> Enum.map(fn {name, layer} ->
+      {name, %{kernel: layer["kernel"], bias: layer["bias"]}}
+    end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/soothsayer/changepoints.ex
+++ b/lib/soothsayer/changepoints.ex
@@ -1,0 +1,193 @@
+defmodule Soothsayer.Changepoints do
+  @moduledoc """
+  Changepoint detection functionality for piecewise linear trends.
+
+  Computes changepoint positions and builds feature tensors for the trend
+  component. Each changepoint allows the trend slope to change at that position.
+
+  The trend function with changepoints is:
+  ```
+  trend(t) = k * t + m + sum(delta_j * max(0, t - s_j))
+  ```
+
+  Where:
+  - `k` = base growth rate (learned)
+  - `m` = offset (learned)
+  - `s_j` = changepoint positions (computed from data, fixed)
+  - `delta_j` = rate adjustments at each changepoint (learned)
+  """
+
+  @doc """
+  Computes evenly spaced changepoint indices within the first portion of data.
+
+  ## Parameters
+
+    * `n_samples` - Total number of samples in the dataset.
+    * `n_changepoints` - Number of changepoints to create.
+    * `changepoints_range` - Fraction of data to place changepoints in (0-1).
+
+  ## Returns
+
+    A list of indices where changepoints will be placed.
+
+  ## Examples
+
+      iex> Soothsayer.Changepoints.compute_changepoint_indices(100, 5, 0.8)
+      [16, 32, 48, 64, 80]
+
+  """
+  @spec compute_changepoint_indices(non_neg_integer(), non_neg_integer(), float()) ::
+          list(non_neg_integer())
+  def compute_changepoint_indices(_n_samples, 0, _changepoints_range), do: []
+
+  def compute_changepoint_indices(n_samples, n_changepoints, changepoints_range) do
+    max_index = trunc(n_samples * changepoints_range)
+    step = max_index / n_changepoints
+
+    1..n_changepoints
+    |> Enum.map(fn i -> trunc(i * step) end)
+  end
+
+  @doc """
+  Computes changepoint positions as dates from the data.
+
+  ## Parameters
+
+    * `dates` - List of dates in the dataset.
+    * `n_changepoints` - Number of changepoints to create.
+    * `changepoints_range` - Fraction of data to place changepoints in (0-1).
+
+  ## Returns
+
+    A list of dates where changepoints are positioned.
+
+  ## Examples
+
+      iex> dates = Enum.map(0..99, fn i -> Date.add(~D[2023-01-01], i) end)
+      iex> Soothsayer.Changepoints.compute_changepoint_positions(dates, 5, 0.8)
+      [~D[2023-01-17], ~D[2023-02-02], ~D[2023-02-18], ~D[2023-03-06], ~D[2023-03-22]]
+
+  """
+  @spec compute_changepoint_positions(list(Date.t()), non_neg_integer(), float()) ::
+          list(Date.t())
+  def compute_changepoint_positions(_dates, 0, _changepoints_range), do: []
+
+  def compute_changepoint_positions(dates, n_changepoints, changepoints_range) do
+    n_samples = length(dates)
+    indices = compute_changepoint_indices(n_samples, n_changepoints, changepoints_range)
+    Enum.map(indices, fn idx -> Enum.at(dates, idx) end)
+  end
+
+  @doc """
+  Builds changepoint feature tensor computing max(0, t - s_j) for each changepoint.
+
+  ## Parameters
+
+    * `t` - Tensor of time values with shape `{n_samples, 1}`.
+    * `changepoint_positions` - List of numeric changepoint positions.
+
+  ## Returns
+
+    A tensor of shape `{n_samples, n_changepoints}` with changepoint features.
+
+  ## Examples
+
+      iex> t = Nx.tensor([[1.0], [2.0], [3.0]])
+      iex> Soothsayer.Changepoints.build_changepoint_features(t, [1.5])
+      #Nx.Tensor<f32[3][1] [[0.0], [0.5], [1.5]]>
+
+  """
+  @spec build_changepoint_features(Nx.Tensor.t(), list(number())) :: Nx.Tensor.t() | nil
+  def build_changepoint_features(_t, []), do: nil
+
+  def build_changepoint_features(t, changepoint_positions) do
+    t_flat = Nx.flatten(t)
+
+    changepoint_positions
+    |> Enum.map(fn s_j ->
+      t_flat
+      |> Nx.subtract(s_j)
+      |> Nx.max(0)
+    end)
+    |> Nx.stack(axis: 1)
+    |> Nx.as_type({:f, 32})
+  end
+
+  @doc """
+  Builds the complete trend input by concatenating t with changepoint features.
+
+  ## Parameters
+
+    * `t` - Tensor of time values with shape `{n_samples, 1}`.
+    * `changepoint_features` - Tensor of changepoint features with shape `{n_samples, n_changepoints}`.
+
+  ## Returns
+
+    A tensor of shape `{n_samples, 1 + n_changepoints}`.
+
+  ## Examples
+
+      iex> t = Nx.tensor([[1.0], [2.0]])
+      iex> cp_features = Nx.tensor([[0.0, 0.0], [0.5, 0.0]])
+      iex> Soothsayer.Changepoints.build_trend_input(t, cp_features)
+      #Nx.Tensor<f32[2][3] [[1.0, 0.0, 0.0], [2.0, 0.5, 0.0]]>
+
+  """
+  @spec build_trend_input(Nx.Tensor.t(), Nx.Tensor.t() | nil) :: Nx.Tensor.t()
+  def build_trend_input(t, nil), do: t
+
+  def build_trend_input(t, changepoint_features) do
+    Nx.concatenate([t, changepoint_features], axis: 1) |> Nx.as_type({:f, 32})
+  end
+
+  @doc """
+  Converts dates to numeric values (days since first date).
+
+  ## Parameters
+
+    * `dates` - List of dates.
+    * `first_date` - Reference date (typically first date in dataset).
+
+  ## Returns
+
+    A tensor of numeric values representing days since first_date.
+
+  ## Examples
+
+      iex> Soothsayer.Changepoints.date_to_numeric([~D[2023-01-01], ~D[2023-01-02]], ~D[2023-01-01])
+      #Nx.Tensor<f32[2] [0.0, 1.0]>
+
+  """
+  @spec date_to_numeric(list(Date.t()), Date.t()) :: Nx.Tensor.t()
+  def date_to_numeric(dates, first_date) do
+    dates
+    |> Enum.map(fn date -> Date.diff(date, first_date) * 1.0 end)
+    |> Nx.tensor()
+    |> Nx.as_type({:f, 32})
+  end
+
+  @doc """
+  Converts numeric values back to dates.
+
+  ## Parameters
+
+    * `numeric` - List of numeric values (days since first_date).
+    * `first_date` - Reference date.
+
+  ## Returns
+
+    A list of dates.
+
+  ## Examples
+
+      iex> Soothsayer.Changepoints.numeric_to_date([0.0, 1.0], ~D[2023-01-01])
+      [~D[2023-01-01], ~D[2023-01-02]]
+
+  """
+  @spec numeric_to_date(list(number()), Date.t()) :: list(Date.t())
+  def numeric_to_date(numeric, first_date) do
+    Enum.map(numeric, fn days ->
+      Date.add(first_date, trunc(days))
+    end)
+  end
+end

--- a/lib/soothsayer/model.ex
+++ b/lib/soothsayer/model.ex
@@ -3,6 +3,8 @@ defmodule Soothsayer.Model do
   Defines the structure and operations for the Soothsayer forecasting model.
   """
 
+  alias Soothsayer.Trainer
+
   defstruct [:network, :params, :config]
 
   @type t :: %__MODULE__{
@@ -57,13 +59,14 @@ defmodule Soothsayer.Model do
   """
   @spec build_network(map()) :: Axon.t()
   def build_network(config) do
-    trend_input = Axon.input("trend", shape: {nil, 1})
+    n_changepoints = get_in(config, [:trend, :n_changepoints]) || 0
+    trend_input = Axon.input("trend", shape: {nil, 1 + n_changepoints})
     yearly_input = Axon.input("yearly", shape: {nil, 2 * config.seasonality.yearly.fourier_terms})
     weekly_input = Axon.input("weekly", shape: {nil, 2 * config.seasonality.weekly.fourier_terms})
 
     trend =
       if config.trend.enabled do
-        Axon.dense(trend_input, 1, activation: :linear)
+        Axon.dense(trend_input, 1, activation: :linear, name: "trend_dense")
       else
         Axon.constant(0)
       end
@@ -146,98 +149,8 @@ defmodule Soothsayer.Model do
   """
   @spec fit(t(), %{String.t() => Nx.Tensor.t()}, Nx.Tensor.t(), non_neg_integer()) :: t()
   def fit(model, x, y, epochs) do
-    {init_fn, _predict_fn} = Axon.build(model.network)
-    initial_params = init_fn.(x, Axon.ModelState.empty())
-
-    ar_reg = get_in(model.config, [:ar, :regularization])
-
-    trained_params =
-      if ar_reg do
-        # Custom training with L1 regularization on AR weights
-        train_with_regularization(model, x, y, epochs, initial_params, ar_reg)
-      else
-        # Standard training without regularization
-        model.network
-        |> Axon.Loop.trainer(
-          &Axon.Losses.huber(&1, &2.combined, reduction: :mean),
-          Polaris.Optimizers.adam(learning_rate: model.config.learning_rate)
-        )
-        |> Axon.Loop.run(Stream.repeatedly(fn -> {x, y} end), initial_params,
-          epochs: epochs,
-          iterations: elem(Nx.shape(y), 0),
-          compiler: EXLA
-        )
-      end
-
+    trained_params = Trainer.fit(model.network, x, y, epochs, model.config)
     %{model | params: trained_params}
-  end
-
-  @doc false
-  def train_with_regularization_public(model, x, y, epochs, initial_params, ar_reg) do
-    train_with_regularization(model, x, y, epochs, initial_params, ar_reg)
-  end
-
-  defp train_with_regularization(model, x, y, epochs, initial_params, ar_reg) do
-    # Find AR layer names at runtime
-    ar_layer_names =
-      initial_params.data
-      |> Map.keys()
-      |> Enum.filter(&String.starts_with?(&1, "ar_dense"))
-
-    {_init_fn, predict_fn} = Axon.build(model.network)
-    {init_optim_fn, update_fn} = Polaris.Optimizers.adam(learning_rate: model.config.learning_rate)
-
-    # Define the objective function with L1 penalty
-    objective_fn = fn params, x_input, y_target ->
-      predictions = predict_fn.(params, x_input)
-      base_loss = Axon.Losses.huber(y_target, predictions.combined, reduction: :mean)
-      ar_penalty = compute_ar_l1_penalty_jit(params, ar_layer_names)
-      Nx.add(base_loss, Nx.multiply(ar_reg, ar_penalty))
-    end
-
-    # JIT compile the train step
-    train_step_fn = fn params, opt_state, x_input, y_target ->
-      {loss, grads} = Nx.Defn.value_and_grad(params, fn p -> objective_fn.(p, x_input, y_target) end)
-      {updates, new_opt_state} = update_fn.(grads, opt_state, params)
-      new_params = Polaris.Updates.apply_updates(params, updates)
-      {loss, new_params, new_opt_state}
-    end
-
-    jit_train_step = EXLA.jit(train_step_fn)
-
-    initial_opt_state = init_optim_fn.(initial_params)
-    iterations = elem(Nx.shape(y), 0)
-
-    log_interval = max(div(epochs, 10), 1)
-
-    {final_params, _final_opt_state} =
-      Enum.reduce(1..epochs, {initial_params, initial_opt_state}, fn epoch, {params, opt_state} ->
-        {final_loss, new_params, new_opt_state} =
-          Enum.reduce(1..iterations, {nil, params, opt_state}, fn _iter, {_loss, p, os} ->
-            jit_train_step.(p, os, x, y)
-          end)
-
-        if rem(epoch - 1, log_interval) == 0 do
-          IO.puts("Epoch: #{epoch - 1}, loss: #{Nx.to_number(final_loss)}")
-        end
-
-        {new_params, new_opt_state}
-      end)
-
-    final_params
-  end
-
-  defp compute_ar_l1_penalty_jit(params, ar_layer_names) do
-    if Enum.empty?(ar_layer_names) do
-      Nx.tensor(0.0)
-    else
-      ar_layer_names
-      |> Enum.map(fn layer_name ->
-        kernel = params.data[layer_name]["kernel"]
-        Nx.sum(Nx.abs(kernel))
-      end)
-      |> Enum.reduce(&Nx.add/2)
-    end
   end
 
   @doc """

--- a/lib/soothsayer/preprocessor.ex
+++ b/lib/soothsayer/preprocessor.ex
@@ -99,45 +99,4 @@ defmodule Soothsayer.Preprocessor do
     result_df
   end
 
-  @doc """
-  Creates lagged input windows from a time series for auto-regression.
-
-  ## Parameters
-
-    * `y` - An `Nx.Tensor` containing the target values (1D).
-    * `n_lags` - The number of lagged values to include in each window.
-
-  ## Returns
-
-    A tuple `{lagged_inputs, targets}` where:
-    - `lagged_inputs` is a tensor of shape `{n_samples, n_lags}` containing sliding windows
-    - `targets` is a tensor of shape `{n_samples, 1}` containing the target values
-
-  ## Examples
-
-      iex> y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-      iex> {lagged, targets} = Soothsayer.Preprocessor.create_lagged_inputs(y, 3)
-      iex> Nx.shape(lagged)
-      {2, 3}
-
-  """
-  @spec create_lagged_inputs(Nx.Tensor.t(), non_neg_integer()) ::
-          {Nx.Tensor.t(), Nx.Tensor.t()}
-  def create_lagged_inputs(y, n_lags) do
-    y = Nx.flatten(y)
-    total = Nx.axis_size(y, 0)
-    n_samples = total - n_lags
-
-    lagged =
-      Enum.map(0..(n_samples - 1), fn i ->
-        Nx.slice(y, [i], [n_lags])
-      end)
-      |> Nx.stack()
-
-    targets =
-      Nx.slice(y, [n_lags], [n_samples])
-      |> Nx.reshape({n_samples, 1})
-
-    {lagged, targets}
-  end
 end

--- a/lib/soothsayer/trainer.ex
+++ b/lib/soothsayer/trainer.ex
@@ -1,0 +1,189 @@
+defmodule Soothsayer.Trainer do
+  @moduledoc """
+  Training functionality for Soothsayer models.
+
+  Handles standard training and custom training with L1 regularization
+  on specified layer weights (AR, trend, etc.).
+  """
+
+  @doc """
+  Trains a network on the provided data.
+
+  ## Parameters
+
+    * `network` - An Axon neural network.
+    * `x` - A map of input tensors.
+    * `y` - A tensor of target values.
+    * `epochs` - The number of training epochs.
+    * `config` - A map containing training configuration:
+      - `:learning_rate` - Learning rate for the optimizer.
+      - `:ar` - Optional map with `:regularization` for AR L1 penalty.
+      - `:trend` - Optional map with `:regularization` for trend L1 penalty.
+
+  ## Returns
+
+    The trained `Axon.ModelState`.
+
+  ## Examples
+
+      iex> config = %{learning_rate: 0.1}
+      iex> params = Soothsayer.Trainer.fit(network, x, y, 100, config)
+      %Axon.ModelState{...}
+
+  """
+  @spec fit(Axon.t(), %{String.t() => Nx.Tensor.t()}, Nx.Tensor.t(), non_neg_integer(), map()) ::
+          Axon.ModelState.t()
+  def fit(network, x, y, epochs, config) do
+    {init_fn, _predict_fn} = Axon.build(network)
+    initial_params = init_fn.(x, Axon.ModelState.empty())
+
+    ar_reg = get_in(config, [:ar, :regularization])
+    trend_reg = get_in(config, [:trend, :regularization])
+
+    if ar_reg || trend_reg do
+      train_with_regularization(network, x, y, epochs, initial_params, config)
+    else
+      train_standard(network, x, y, epochs, initial_params, config)
+    end
+  end
+
+  @doc """
+  Computes L1 penalty for specified layer kernels.
+
+  ## Parameters
+
+    * `params` - An `Axon.ModelState` containing the model parameters.
+    * `layer_names` - A list of layer names to include in the penalty.
+
+  ## Returns
+
+    A scalar tensor with the sum of absolute values of all kernel weights
+    in the specified layers.
+
+  ## Examples
+
+      iex> penalty = Soothsayer.Trainer.compute_l1_penalty(params, ["ar_dense_out"])
+      #Nx.Tensor<f32 6.0>
+
+  """
+  @spec compute_l1_penalty(Axon.ModelState.t(), list(String.t())) :: Nx.Tensor.t()
+  def compute_l1_penalty(params, layer_names) do
+    if Enum.empty?(layer_names) do
+      Nx.tensor(0.0)
+    else
+      layer_names
+      |> Enum.map(fn layer_name ->
+        kernel = params.data[layer_name]["kernel"]
+        Nx.sum(Nx.abs(kernel))
+      end)
+      |> Enum.reduce(&Nx.add/2)
+    end
+  end
+
+  defp train_standard(network, x, y, epochs, initial_params, config) do
+    network
+    |> Axon.Loop.trainer(
+      &Axon.Losses.huber(&1, &2.combined, reduction: :mean),
+      Polaris.Optimizers.adam(learning_rate: config.learning_rate)
+    )
+    |> Axon.Loop.run(Stream.repeatedly(fn -> {x, y} end), initial_params,
+      epochs: epochs,
+      iterations: elem(Nx.shape(y), 0),
+      compiler: EXLA
+    )
+  end
+
+  defp train_with_regularization(network, x, y, epochs, initial_params, config) do
+    ar_reg = get_in(config, [:ar, :regularization]) || 0.0
+    trend_reg = get_in(config, [:trend, :regularization]) || 0.0
+
+    regularization_layers = build_regularization_layers(initial_params, ar_reg, trend_reg)
+
+    {_init_fn, predict_fn} = Axon.build(network)
+    {init_optim_fn, update_fn} = Polaris.Optimizers.adam(learning_rate: config.learning_rate)
+
+    objective_fn = build_objective_fn(predict_fn, regularization_layers)
+    train_step_fn = build_train_step_fn(objective_fn, update_fn)
+    jit_train_step = EXLA.jit(train_step_fn)
+
+    initial_opt_state = init_optim_fn.(initial_params)
+    iterations = elem(Nx.shape(y), 0)
+
+    run_training_loop(epochs, iterations, initial_params, initial_opt_state, x, y, jit_train_step)
+  end
+
+  defp build_regularization_layers(params, ar_reg, trend_reg) do
+    ar_layers =
+      if ar_reg > 0 do
+        params.data
+        |> Map.keys()
+        |> Enum.filter(&String.starts_with?(&1, "ar_dense"))
+        |> Enum.map(fn name -> {name, ar_reg} end)
+      else
+        []
+      end
+
+    trend_layers =
+      if trend_reg > 0 do
+        params.data
+        |> Map.keys()
+        |> Enum.filter(&String.starts_with?(&1, "trend_dense"))
+        |> Enum.map(fn name -> {name, trend_reg} end)
+      else
+        []
+      end
+
+    ar_layers ++ trend_layers
+  end
+
+  defp build_objective_fn(predict_fn, regularization_layers) do
+    fn params, x_input, y_target ->
+      predictions = predict_fn.(params, x_input)
+      base_loss = Axon.Losses.huber(y_target, predictions.combined, reduction: :mean)
+      penalty = compute_weighted_l1_penalty(params, regularization_layers)
+      Nx.add(base_loss, penalty)
+    end
+  end
+
+  defp compute_weighted_l1_penalty(params, regularization_layers) do
+    if Enum.empty?(regularization_layers) do
+      Nx.tensor(0.0)
+    else
+      regularization_layers
+      |> Enum.map(fn {layer_name, reg_weight} ->
+        kernel = params.data[layer_name]["kernel"]
+        Nx.multiply(reg_weight, Nx.sum(Nx.abs(kernel)))
+      end)
+      |> Enum.reduce(&Nx.add/2)
+    end
+  end
+
+  defp build_train_step_fn(objective_fn, update_fn) do
+    fn params, opt_state, x_input, y_target ->
+      {loss, grads} = Nx.Defn.value_and_grad(params, fn p -> objective_fn.(p, x_input, y_target) end)
+      {updates, new_opt_state} = update_fn.(grads, opt_state, params)
+      new_params = Polaris.Updates.apply_updates(params, updates)
+      {loss, new_params, new_opt_state}
+    end
+  end
+
+  defp run_training_loop(epochs, iterations, initial_params, initial_opt_state, x, y, jit_train_step) do
+    log_interval = max(div(epochs, 10), 1)
+
+    {final_params, _final_opt_state} =
+      Enum.reduce(1..epochs, {initial_params, initial_opt_state}, fn epoch, {params, opt_state} ->
+        {final_loss, new_params, new_opt_state} =
+          Enum.reduce(1..iterations, {nil, params, opt_state}, fn _iter, {_loss, p, os} ->
+            jit_train_step.(p, os, x, y)
+          end)
+
+        if rem(epoch - 1, log_interval) == 0 do
+          IO.puts("Epoch: #{epoch - 1}, loss: #{Nx.to_number(final_loss)}")
+        end
+
+        {new_params, new_opt_state}
+      end)
+
+    final_params
+  end
+end

--- a/test/soothsayer/ar_module_test.exs
+++ b/test/soothsayer/ar_module_test.exs
@@ -1,0 +1,128 @@
+defmodule Soothsayer.ARModuleTest do
+  use ExUnit.Case, async: true
+
+  alias Soothsayer.AR
+
+  describe "create_lagged_inputs/2" do
+    test "creates sliding windows from y values" do
+      y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      n_lags = 3
+
+      {lagged, targets} = AR.create_lagged_inputs(y, n_lags)
+
+      # With n_lags=3 and 5 values, we get 2 windows:
+      # Window 1: [1, 2, 3] -> target: 4
+      # Window 2: [2, 3, 4] -> target: 5
+      assert Nx.shape(lagged) == {2, 3}
+      assert Nx.shape(targets) == {2, 1}
+      assert Nx.to_flat_list(lagged) == [1.0, 2.0, 3.0, 2.0, 3.0, 4.0]
+      assert Nx.to_flat_list(targets) == [4.0, 5.0]
+    end
+  end
+
+  describe "build_input/3" do
+    test "builds AR input tensor from training data and dates" do
+      training_data = %{
+        dates: [~D[2023-01-01], ~D[2023-01-02], ~D[2023-01-03], ~D[2023-01-04], ~D[2023-01-05]],
+        y_normalized: [1.0, 2.0, 3.0, 4.0, 5.0]
+      }
+      n_lags = 2
+      prediction_dates = [~D[2023-01-04], ~D[2023-01-05]]
+
+      result = AR.build_input(training_data, prediction_dates, n_lags)
+
+      # For date 2023-01-04 (idx 3), lags are [2.0, 3.0]
+      # For date 2023-01-05 (idx 4), lags are [3.0, 4.0]
+      assert Nx.shape(result) == {2, 2}
+      assert Nx.to_flat_list(result) == [2.0, 3.0, 3.0, 4.0]
+    end
+
+    test "returns zeros for dates at beginning of series" do
+      training_data = %{
+        dates: [~D[2023-01-01], ~D[2023-01-02], ~D[2023-01-03]],
+        y_normalized: [1.0, 2.0, 3.0]
+      }
+      n_lags = 2
+      prediction_dates = [~D[2023-01-01], ~D[2023-01-02]]
+
+      result = AR.build_input(training_data, prediction_dates, n_lags)
+
+      # Both dates don't have enough history, should return zeros
+      assert Nx.to_flat_list(result) == [0.0, 0.0, 0.0, 0.0]
+    end
+  end
+
+  describe "get_weights/1" do
+    test "returns weights for linear AR model" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = Explorer.DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false, n_changepoints: 0},
+          seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+          ar: %{enabled: true, n_lags: 3},
+          epochs: 2
+        })
+
+      fitted_model = Soothsayer.fit(model, df)
+      weights = AR.get_weights(fitted_model)
+
+      assert Map.has_key?(weights, "ar_dense_out")
+      assert map_size(weights) == 1
+      assert Nx.shape(weights["ar_dense_out"].kernel) == {3, 1}
+      assert Nx.shape(weights["ar_dense_out"].bias) == {1}
+    end
+
+    test "returns all layer weights for deep AR-Net" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = Explorer.DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model =
+        Soothsayer.new(%{
+          trend: %{enabled: false, n_changepoints: 0},
+          seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+          ar: %{enabled: true, n_lags: 5, layers: [16, 8]},
+          epochs: 2
+        })
+
+      fitted_model = Soothsayer.fit(model, df)
+      weights = AR.get_weights(fitted_model)
+
+      assert Map.has_key?(weights, "ar_dense_0")
+      assert Map.has_key?(weights, "ar_dense_1")
+      assert Map.has_key?(weights, "ar_dense_out")
+      assert Nx.shape(weights["ar_dense_0"].kernel) == {5, 16}
+      assert Nx.shape(weights["ar_dense_1"].kernel) == {16, 8}
+      assert Nx.shape(weights["ar_dense_out"].kernel) == {8, 1}
+    end
+
+    test "raises error when AR is disabled" do
+      model = Soothsayer.new(%{ar: %{enabled: false}})
+
+      assert_raise ArgumentError, ~r/AR is not enabled/, fn ->
+        AR.get_weights(model)
+      end
+    end
+
+    test "raises error when model is not fitted" do
+      model = Soothsayer.new(%{ar: %{enabled: true, n_lags: 3}})
+
+      assert_raise ArgumentError, ~r/not been fitted/, fn ->
+        AR.get_weights(model)
+      end
+    end
+  end
+end

--- a/test/soothsayer/ar_test.exs
+++ b/test/soothsayer/ar_test.exs
@@ -3,7 +3,7 @@ defmodule Soothsayer.ARTest do
 
   alias Explorer.DataFrame
   alias Explorer.Series
-  alias Soothsayer.Preprocessor
+  alias Soothsayer.AR
 
   describe "auto-regression config" do
     test "new/1 includes AR config with defaults" do
@@ -21,7 +21,7 @@ defmodule Soothsayer.ARTest do
       y = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
       n_lags = 3
 
-      {lagged, targets} = Preprocessor.create_lagged_inputs(y, n_lags)
+      {lagged, targets} = AR.create_lagged_inputs(y, n_lags)
 
       # With n_lags=3 and 5 values, we get 2 windows:
       # Window 1: [1, 2, 3] -> target: 4
@@ -147,16 +147,10 @@ defmodule Soothsayer.ARTest do
           compiler: EXLA
         )
 
-      # Train model WITH regularization using same initial params
-      # We use the Model.fit with regularization which uses custom training loop
-      model_with_reg = %Soothsayer.Model{
-        network: network,
-        config: %{learning_rate: 0.1, ar: %{regularization: 1.0}}
-      }
-
-      trained_reg = Soothsayer.Model.train_with_regularization_public(
-        model_with_reg, input, target, 100, initial_params, 1.0
-      )
+      # Train model WITH regularization
+      # We use the Trainer module with regularization which uses custom training loop
+      config_with_reg = %{learning_rate: 0.1, ar: %{regularization: 1.0}}
+      trained_reg = Soothsayer.Trainer.fit(network, input, target, 100, config_with_reg)
 
       # Get the AR dense layer weights
       ar_weights_reg = trained_reg.data["ar_dense_out"]["kernel"]

--- a/test/soothsayer/changepoints_test.exs
+++ b/test/soothsayer/changepoints_test.exs
@@ -1,0 +1,349 @@
+defmodule Soothsayer.ChangepointsTest do
+  use ExUnit.Case, async: true
+
+  alias Soothsayer.Changepoints
+
+  describe "config defaults" do
+    test "new/1 includes trend changepoint config with defaults" do
+      model = Soothsayer.new()
+
+      assert model.config.trend.n_changepoints == 10
+      assert model.config.trend.changepoints_range == 0.8
+      assert model.config.trend.regularization == nil
+    end
+
+    test "n_changepoints: 0 disables changepoints" do
+      model = Soothsayer.new(%{trend: %{n_changepoints: 0}})
+
+      assert model.config.trend.n_changepoints == 0
+    end
+  end
+
+  describe "network with changepoints" do
+    test "build_network has trend input shape {nil, 1} when n_changepoints is 0" do
+      config = %{
+        trend: %{enabled: true, n_changepoints: 0, changepoints_range: 0.8, regularization: nil},
+        seasonality: %{
+          yearly: %{enabled: false, fourier_terms: 4},
+          weekly: %{enabled: false, fourier_terms: 2}
+        },
+        ar: %{enabled: false, n_lags: 0}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+      inputs = Axon.get_inputs(network)
+
+      assert inputs["trend"] == {nil, 1}
+    end
+
+    test "build_network has trend input shape {nil, 1 + n_changepoints} when changepoints enabled" do
+      config = %{
+        trend: %{enabled: true, n_changepoints: 5, changepoints_range: 0.8, regularization: nil},
+        seasonality: %{
+          yearly: %{enabled: false, fourier_terms: 4},
+          weekly: %{enabled: false, fourier_terms: 2}
+        },
+        ar: %{enabled: false, n_lags: 0}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+      inputs = Axon.get_inputs(network)
+
+      assert inputs["trend"] == {nil, 6}
+    end
+
+    test "build_network names trend layer 'trend_dense' for regularization" do
+      config = %{
+        trend: %{enabled: true, n_changepoints: 5, changepoints_range: 0.8, regularization: nil},
+        seasonality: %{
+          yearly: %{enabled: false, fourier_terms: 4},
+          weekly: %{enabled: false, fourier_terms: 2}
+        },
+        ar: %{enabled: false, n_lags: 0}
+      }
+
+      network = Soothsayer.Model.build_network(config)
+      {init_fn, _predict_fn} = Axon.build(network)
+
+      input = %{
+        "trend" => Nx.broadcast(0.0, {1, 6}),
+        "yearly" => Nx.broadcast(0.0, {1, 8}),
+        "weekly" => Nx.broadcast(0.0, {1, 4})
+      }
+      params = init_fn.(input, Axon.ModelState.empty())
+
+      assert Map.has_key?(params.data, "trend_dense")
+    end
+  end
+
+  describe "compute_changepoint_indices/3" do
+    test "returns empty list when n_changepoints is 0" do
+      result = Changepoints.compute_changepoint_indices(100, 0, 0.8)
+      assert result == []
+    end
+
+    test "returns evenly spaced indices in the first portion of data" do
+      # 100 samples, 5 changepoints, 80% range = first 80 samples
+      # Changepoints at: 16, 32, 48, 64, 80 (evenly spaced)
+      result = Changepoints.compute_changepoint_indices(100, 5, 0.8)
+
+      assert length(result) == 5
+      assert Enum.all?(result, fn idx -> idx >= 0 and idx <= 80 end)
+      # Check that indices are evenly spaced
+      [first | _rest] = result
+      spacing = Enum.at(result, 1) - first
+      assert Enum.all?(Enum.chunk_every(result, 2, 1, :discard), fn [a, b] ->
+        b - a == spacing
+      end)
+    end
+
+    test "respects changepoints_range parameter" do
+      # 100 samples, 5 changepoints, 50% range = first 50 samples
+      result = Changepoints.compute_changepoint_indices(100, 5, 0.5)
+
+      assert length(result) == 5
+      assert Enum.all?(result, fn idx -> idx >= 0 and idx <= 50 end)
+    end
+
+    test "handles edge case with few samples" do
+      result = Changepoints.compute_changepoint_indices(10, 3, 0.8)
+
+      assert length(result) == 3
+      assert Enum.all?(result, fn idx -> idx >= 0 and idx <= 8 end)
+    end
+  end
+
+  describe "compute_changepoint_positions/3" do
+    test "returns dates at computed indices" do
+      dates = Enum.map(0..99, fn i -> Date.add(~D[2023-01-01], i) end)
+
+      result = Changepoints.compute_changepoint_positions(dates, 5, 0.8)
+
+      assert length(result) == 5
+      assert Enum.all?(result, fn date -> date in dates end)
+      # First 80 days = up to index 80
+      assert Enum.all?(result, fn date -> Date.compare(date, ~D[2023-03-23]) != :gt end)
+    end
+
+    test "returns empty list when n_changepoints is 0" do
+      dates = Enum.map(0..99, fn i -> Date.add(~D[2023-01-01], i) end)
+
+      result = Changepoints.compute_changepoint_positions(dates, 0, 0.8)
+
+      assert result == []
+    end
+  end
+
+  describe "build_changepoint_features/2" do
+    test "returns nil when no changepoint positions" do
+      t = Nx.tensor([[1.0], [2.0], [3.0]])
+
+      result = Changepoints.build_changepoint_features(t, [])
+
+      assert result == nil
+    end
+
+    test "computes max(0, t - s_j) for each changepoint" do
+      # t values: 1, 2, 3, 4, 5
+      # changepoint at t=2.5
+      # Expected: max(0, 1-2.5)=0, max(0, 2-2.5)=0, max(0, 3-2.5)=0.5, max(0, 4-2.5)=1.5, max(0, 5-2.5)=2.5
+      t = Nx.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+      changepoint_positions = [2.5]
+
+      result = Changepoints.build_changepoint_features(t, changepoint_positions)
+
+      assert Nx.shape(result) == {5, 1}
+      expected = Nx.tensor([[0.0], [0.0], [0.5], [1.5], [2.5]])
+      assert Nx.to_flat_list(result) == Nx.to_flat_list(expected)
+    end
+
+    test "handles multiple changepoints" do
+      # t values: 1, 2, 3, 4, 5
+      # changepoints at t=1.5 and t=3.5
+      t = Nx.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+      changepoint_positions = [1.5, 3.5]
+
+      result = Changepoints.build_changepoint_features(t, changepoint_positions)
+
+      assert Nx.shape(result) == {5, 2}
+      # Column 0: max(0, t-1.5) = [0, 0.5, 1.5, 2.5, 3.5]
+      # Column 1: max(0, t-3.5) = [0, 0, 0, 0.5, 1.5]
+      expected = Nx.tensor([
+        [0.0, 0.0],
+        [0.5, 0.0],
+        [1.5, 0.0],
+        [2.5, 0.5],
+        [3.5, 1.5]
+      ])
+      assert Nx.to_flat_list(result) == Nx.to_flat_list(expected)
+    end
+  end
+
+  describe "build_trend_input/2" do
+    test "returns t when no changepoints" do
+      t = Nx.tensor([[1.0], [2.0], [3.0]])
+
+      result = Changepoints.build_trend_input(t, nil)
+
+      assert Nx.shape(result) == {3, 1}
+      assert Nx.to_flat_list(result) == Nx.to_flat_list(t)
+    end
+
+    test "concatenates t with changepoint features" do
+      t = Nx.tensor([[1.0], [2.0], [3.0]])
+      changepoint_features = Nx.tensor([[0.0, 0.0], [0.5, 0.0], [1.5, 0.5]])
+
+      result = Changepoints.build_trend_input(t, changepoint_features)
+
+      assert Nx.shape(result) == {3, 3}
+      expected = Nx.tensor([
+        [1.0, 0.0, 0.0],
+        [2.0, 0.5, 0.0],
+        [3.0, 1.5, 0.5]
+      ])
+      assert Nx.to_flat_list(result) == Nx.to_flat_list(expected)
+    end
+  end
+
+  describe "date_to_numeric/2" do
+    test "converts dates to numeric values relative to first date" do
+      dates = [~D[2023-01-01], ~D[2023-01-02], ~D[2023-01-03]]
+      first_date = ~D[2023-01-01]
+
+      result = Changepoints.date_to_numeric(dates, first_date)
+
+      assert Nx.to_flat_list(result) == [0.0, 1.0, 2.0]
+    end
+
+    test "handles single date" do
+      dates = [~D[2023-01-01]]
+      first_date = ~D[2023-01-01]
+
+      result = Changepoints.date_to_numeric(dates, first_date)
+
+      assert Nx.to_flat_list(result) == [0.0]
+    end
+  end
+
+  describe "numeric_to_date/2" do
+    test "converts numeric values back to dates" do
+      numeric = [0.0, 1.0, 2.0]
+      first_date = ~D[2023-01-01]
+
+      result = Changepoints.numeric_to_date(numeric, first_date)
+
+      assert result == [~D[2023-01-01], ~D[2023-01-02], ~D[2023-01-03]]
+    end
+  end
+
+  describe "fit/predict integration" do
+    alias Explorer.DataFrame
+    alias Explorer.Series
+
+    test "stores changepoint_positions in model config after fit" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 100
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model = Soothsayer.new(%{
+        trend: %{n_changepoints: 5, changepoints_range: 0.8},
+        seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+        epochs: 2
+      })
+
+      fitted_model = Soothsayer.fit(model, df)
+
+      # Changepoint positions should be stored as numeric values
+      assert Map.has_key?(fitted_model.config, :changepoint_positions)
+      assert length(fitted_model.config.changepoint_positions) == 5
+      # All positions should be numeric (days since first date)
+      assert Enum.all?(fitted_model.config.changepoint_positions, &is_number/1)
+    end
+
+    test "fit and predict with changepoints enabled" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 100
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      # Generate data with a trend that changes slope
+      y_values = Enum.map(0..(n_points - 1), fn i ->
+        base = if i < 50, do: i * 1.0, else: 50.0 + (i - 50) * 2.0
+        base + :rand.normal(0, 2)
+      end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model = Soothsayer.new(%{
+        trend: %{n_changepoints: 5, changepoints_range: 0.8},
+        seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+        epochs: 5
+      })
+
+      fitted_model = Soothsayer.fit(model, df)
+
+      # Predict on last 10 dates
+      test_dates = Enum.take(dates, -10) |> Series.from_list()
+      predictions = Soothsayer.predict(fitted_model, test_dates)
+
+      assert Nx.shape(predictions) == {10, 1}
+      # Model should produce reasonable predictions (not all zeros)
+      pred_values = Nx.to_flat_list(predictions)
+      assert Enum.any?(pred_values, fn v -> abs(v) > 1.0 end)
+    end
+
+    test "n_changepoints: 0 works (backward compatible)" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model = Soothsayer.new(%{
+        trend: %{n_changepoints: 0},
+        seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+        epochs: 2
+      })
+
+      fitted_model = Soothsayer.fit(model, df)
+
+      # Should have empty changepoint_positions
+      assert fitted_model.config.changepoint_positions == []
+
+      # Predict should still work
+      test_dates = Enum.take(dates, -5) |> Series.from_list()
+      predictions = Soothsayer.predict(fitted_model, test_dates)
+
+      assert Nx.shape(predictions) == {5, 1}
+    end
+
+    test "stores first_date for prediction" do
+      :rand.seed(:exsss, {42, 42, 42})
+
+      n_points = 50
+      start_date = ~D[2023-01-01]
+      dates = Enum.map(0..(n_points - 1), fn i -> Date.add(start_date, i) end)
+      y_values = Enum.map(1..n_points, fn i -> i * 1.0 + :rand.normal(0, 1) end)
+
+      df = DataFrame.new(%{"ds" => dates, "y" => y_values})
+
+      model = Soothsayer.new(%{
+        trend: %{n_changepoints: 3},
+        seasonality: %{yearly: %{enabled: false}, weekly: %{enabled: false}},
+        epochs: 2
+      })
+
+      fitted_model = Soothsayer.fit(model, df)
+
+      assert fitted_model.config.first_date == start_date
+    end
+  end
+end

--- a/test/soothsayer/trainer_test.exs
+++ b/test/soothsayer/trainer_test.exs
@@ -1,0 +1,123 @@
+defmodule Soothsayer.TrainerTest do
+  use ExUnit.Case, async: true
+
+  alias Soothsayer.Trainer
+
+  describe "fit/5" do
+    test "trains network without regularization" do
+      # Simple network: one dense layer
+      network =
+        Axon.input("x", shape: {nil, 2})
+        |> Axon.dense(1, activation: :linear)
+        |> then(&Axon.container(%{combined: &1}))
+
+      x = %{"x" => Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])}
+      y = Nx.tensor([[3.0], [7.0], [11.0]])
+
+      config = %{learning_rate: 0.1}
+
+      params = Trainer.fit(network, x, y, 10, config)
+
+      assert params != nil
+      assert is_struct(params, Axon.ModelState)
+    end
+
+    test "trains network with AR regularization" do
+      network =
+        Axon.input("x", shape: {nil, 2})
+        |> Axon.dense(1, activation: :linear, name: "ar_dense_out")
+        |> then(&Axon.container(%{combined: &1}))
+
+      x = %{"x" => Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])}
+      y = Nx.tensor([[3.0], [7.0], [11.0]])
+
+      config = %{learning_rate: 0.1, ar: %{regularization: 0.1}}
+
+      params = Trainer.fit(network, x, y, 10, config)
+
+      assert params != nil
+      assert is_struct(params, Axon.ModelState)
+    end
+
+    test "trains network with trend regularization" do
+      network =
+        Axon.input("x", shape: {nil, 2})
+        |> Axon.dense(1, activation: :linear, name: "trend_dense")
+        |> then(&Axon.container(%{combined: &1}))
+
+      x = %{"x" => Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])}
+      y = Nx.tensor([[3.0], [7.0], [11.0]])
+
+      config = %{learning_rate: 0.1, trend: %{regularization: 0.1}}
+
+      params = Trainer.fit(network, x, y, 10, config)
+
+      assert params != nil
+      assert is_struct(params, Axon.ModelState)
+    end
+
+    test "trains network with both AR and trend regularization" do
+      ar_input = Axon.input("ar", shape: {nil, 2})
+      trend_input = Axon.input("trend", shape: {nil, 2})
+
+      ar = Axon.dense(ar_input, 1, activation: :linear, name: "ar_dense_out")
+      trend = Axon.dense(trend_input, 1, activation: :linear, name: "trend_dense")
+      combined = Axon.add([ar, trend])
+
+      network = Axon.container(%{combined: combined, ar: ar, trend: trend})
+
+      x = %{
+        "ar" => Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+        "trend" => Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+      }
+      y = Nx.tensor([[3.0], [7.0], [11.0]])
+
+      config = %{
+        learning_rate: 0.1,
+        ar: %{regularization: 0.1},
+        trend: %{regularization: 0.1}
+      }
+
+      params = Trainer.fit(network, x, y, 10, config)
+
+      assert params != nil
+      assert is_struct(params, Axon.ModelState)
+    end
+  end
+
+  describe "compute_l1_penalty/2" do
+    test "returns zero for empty layer list" do
+      params = %Axon.ModelState{data: %{}}
+      result = Trainer.compute_l1_penalty(params, [])
+
+      assert Nx.to_number(result) == 0.0
+    end
+
+    test "computes L1 penalty for single layer" do
+      params = %Axon.ModelState{
+        data: %{
+          "dense" => %{"kernel" => Nx.tensor([[1.0], [-2.0], [3.0]])}
+        }
+      }
+
+      result = Trainer.compute_l1_penalty(params, ["dense"])
+
+      # |1| + |-2| + |3| = 6
+      assert Nx.to_number(result) == 6.0
+    end
+
+    test "computes L1 penalty for multiple layers" do
+      params = %Axon.ModelState{
+        data: %{
+          "layer1" => %{"kernel" => Nx.tensor([[1.0], [-1.0]])},
+          "layer2" => %{"kernel" => Nx.tensor([[2.0], [-2.0]])}
+        }
+      }
+
+      result = Trainer.compute_l1_penalty(params, ["layer1", "layer2"])
+
+      # (|1| + |-1|) + (|2| + |-2|) = 2 + 4 = 6
+      assert Nx.to_number(result) == 6.0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add automatic changepoint detection for the trend component, allowing the trend slope to change at multiple points
- Extract Trainer module with L1 regularization support for both AR and trend weights
- Add Changepoints module for computing positions and building feature tensors
- Dynamic trend input shape based on `n_changepoints` configuration
- Backward compatible: `n_changepoints: 0` uses simple linear trend

## Configuration

```elixir
Soothsayer.new(%{
  trend: %{
    n_changepoints: 10,      # number of potential changepoints (default)
    changepoints_range: 0.8, # place in first 80% of data
    regularization: 0.1      # optional L1 penalty
  }
})
```